### PR TITLE
fix: use unique useAsyncData key per page slug

### DIFF
--- a/src/runtime/composables/useWpPage.ts
+++ b/src/runtime/composables/useWpPage.ts
@@ -14,7 +14,7 @@ const useWpPage = async ({ slug }: Options = {}): Promise<Page> => {
     query = useRuntimeConfig().public.wordpress.homeSlug
   }
 
-  const { data, error } = await useAsyncData<Array<Page>>('page', async () => {
+  const { data, error } = await useAsyncData<Array<Page>>(`page-${query}`, async () => {
     const { apiEndpoint, additonnalQueryParams } = useRuntimeConfig().public.wordpress
     return $fetch(`${apiEndpoint}/pages?slug=${query}${additonnalQueryParams}`)
   })


### PR DESCRIPTION
useAsyncData is called with a hardcoded key "page" for all pages. This causes cache collisions during client-side navigation